### PR TITLE
Add minimal MVP skeleton

### DIFF
--- a/MTSI-Team9-Ingredii/README.md
+++ b/MTSI-Team9-Ingredii/README.md
@@ -1,1 +1,24 @@
-# MTSI Team 9 Ingredii
+# Ingredii MVP
+
+This repository contains a minimal proof of concept for the Ingredii project. The goal is to provide a lightweight skeleton demonstrating the major components:
+
+- **Firmware** running on a microcontroller
+- **Backend API** built with FastAPI
+- **Scripts** for image preprocessing and model training
+- **Documentation** outlining the concept and requirements
+
+The project is not production ready but offers a starting point for experimentation.
+
+## Usage
+
+1. Install Python dependencies:
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   pip install -r software/backend/requirements.txt
+   ```
+2. Start the backend:
+   ```bash
+   uvicorn api.main:app --reload --app-dir software/backend/src
+   ```
+3. Run preprocessing and training scripts from the `scripts` directory as needed.

--- a/MTSI-Team9-Ingredii/data/expiry_dataset.csv
+++ b/MTSI-Team9-Ingredii/data/expiry_dataset.csv
@@ -1,0 +1,3 @@
+item,expiry_days
+milk,7
+bread,3

--- a/MTSI-Team9-Ingredii/docs/design_specifications/system_architecture.md
+++ b/MTSI-Team9-Ingredii/docs/design_specifications/system_architecture.md
@@ -1,0 +1,3 @@
+# System Architecture
+
+The system is composed of a camera-enabled microcontroller that sends images to a FastAPI backend for processing. The backend runs lightweight models to determine expiration and stores data in memory for the MVP.

--- a/MTSI-Team9-Ingredii/docs/market_research.md
+++ b/MTSI-Team9-Ingredii/docs/market_research.md
@@ -1,0 +1,3 @@
+# Market Research
+
+There is growing demand for reducing food waste at home. Similar products exist, but most require manual data entry. Ingredii aims to automate this process using inexpensive hardware and AI.

--- a/MTSI-Team9-Ingredii/docs/product_concept.md
+++ b/MTSI-Team9-Ingredii/docs/product_concept.md
@@ -1,0 +1,3 @@
+# Product Concept
+
+Ingredii is a smart pantry system that tracks item expiration dates using image recognition. The MVP focuses on capturing photos of products and notifying the backend when items are close to expiring.

--- a/MTSI-Team9-Ingredii/docs/requirements/functional.md
+++ b/MTSI-Team9-Ingredii/docs/requirements/functional.md
@@ -1,0 +1,5 @@
+# Functional Requirements
+
+- Capture product images via firmware
+- Send images to backend for analysis
+- Provide API to query items and expiration info

--- a/MTSI-Team9-Ingredii/docs/requirements/nonfunctional.md
+++ b/MTSI-Team9-Ingredii/docs/requirements/nonfunctional.md
@@ -1,0 +1,4 @@
+# Non‑Functional Requirements
+
+- Easy to set up with minimal hardware
+- Processes images quickly on the backend

--- a/MTSI-Team9-Ingredii/docs/user_personas.md
+++ b/MTSI-Team9-Ingredii/docs/user_personas.md
@@ -1,0 +1,3 @@
+# User Personas
+
+*Busy Parent*: wants to quickly know what food is about to expire without manually checking each item.

--- a/MTSI-Team9-Ingredii/firmware/platformio.ini
+++ b/MTSI-Team9-Ingredii/firmware/platformio.ini
@@ -1,0 +1,5 @@
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino
+monitor_speed = 115200

--- a/MTSI-Team9-Ingredii/firmware/src/main.cpp
+++ b/MTSI-Team9-Ingredii/firmware/src/main.cpp
@@ -1,0 +1,11 @@
+#include <Arduino.h>
+
+void setup() {
+    Serial.begin(115200);
+    Serial.println("Ingredii firmware started");
+}
+
+void loop() {
+    delay(1000);
+    Serial.println("running...");
+}

--- a/MTSI-Team9-Ingredii/scripts/deploy.sh
+++ b/MTSI-Team9-Ingredii/scripts/deploy.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Deploy the FastAPI backend
+uvicorn api.main:app --host 0.0.0.0 --port 8000 --app-dir ../software/backend/src

--- a/MTSI-Team9-Ingredii/scripts/preprocess_images.py
+++ b/MTSI-Team9-Ingredii/scripts/preprocess_images.py
@@ -1,0 +1,14 @@
+"""Simple preprocessing script."""
+
+import pathlib
+from PIL import Image
+
+RAW_DIR = pathlib.Path('../data/raw_images')
+PROC_DIR = pathlib.Path('../data/processed_images')
+PROC_DIR.mkdir(parents=True, exist_ok=True)
+
+for img_path in RAW_DIR.glob('*.jpg'):
+    img = Image.open(img_path).convert('L')
+    out_path = PROC_DIR / img_path.name
+    img.save(out_path)
+    print(f"processed {img_path} -> {out_path}")

--- a/MTSI-Team9-Ingredii/scripts/setup_env.sh
+++ b/MTSI-Team9-Ingredii/scripts/setup_env.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Simple environment setup script
+python3 -m venv venv
+source venv/bin/activate
+pip install -r ../software/backend/requirements.txt

--- a/MTSI-Team9-Ingredii/scripts/train_model.py
+++ b/MTSI-Team9-Ingredii/scripts/train_model.py
@@ -1,0 +1,13 @@
+"""Train a very small model using the expiry dataset."""
+
+import pandas as pd
+from sklearn.linear_model import LinearRegression
+
+CSV_PATH = '../data/expiry_dataset.csv'
+
+if __name__ == '__main__':
+    data = pd.read_csv(CSV_PATH)
+    X = data[['expiry_days']]
+    y = data['expiry_days']  # toy example
+    model = LinearRegression().fit(X, y)
+    print('Model trained with', len(data), 'records')

--- a/MTSI-Team9-Ingredii/software/backend/Dockerfile
+++ b/MTSI-Team9-Ingredii/software/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+COPY src ./src
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000", "--app-dir", "src"]

--- a/MTSI-Team9-Ingredii/software/backend/requirements.txt
+++ b/MTSI-Team9-Ingredii/software/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+pandas
+scikit-learn
+Pillow

--- a/MTSI-Team9-Ingredii/software/backend/src/api/main.py
+++ b/MTSI-Team9-Ingredii/software/backend/src/api/main.py
@@ -1,0 +1,10 @@
+from fastapi import FastAPI
+from . import models
+
+app = FastAPI()
+
+db = models.InMemoryDB()
+
+@app.get('/items')
+def list_items():
+    return db.get_items()

--- a/MTSI-Team9-Ingredii/software/backend/src/api/models.py
+++ b/MTSI-Team9-Ingredii/software/backend/src/api/models.py
@@ -1,0 +1,9 @@
+class InMemoryDB:
+    def __init__(self):
+        self._items = [
+            {"name": "milk", "expiry_days": 7},
+            {"name": "bread", "expiry_days": 3},
+        ]
+
+    def get_items(self):
+        return self._items


### PR DESCRIPTION
## Summary
- flesh out docs with short descriptions
- add dataset sample
- create preprocessing and training scripts
- add simple FastAPI backend and firmware example
- include helper scripts and configuration

## Testing
- `python3 -m py_compile MTSI-Team9-Ingredii/scripts/preprocess_images.py MTSI-Team9-Ingredii/scripts/train_model.py MTSI-Team9-Ingredii/software/backend/src/api/main.py MTSI-Team9-Ingredii/software/backend/src/api/models.py`

------
https://chatgpt.com/codex/tasks/task_e_6876ff78e12c832cb0e69b3e4f18e486