### PR TITLE
Add Ingredii iOS app skeleton

### DIFF
--- a/Ingredii/Ingredii.xcodeproj/project.pbxproj
+++ b/Ingredii/Ingredii.xcodeproj/project.pbxproj
@@ -1,0 +1,1 @@
+// Placeholder Xcode project file

--- a/Ingredii/Ingredii/AppDelegate.swift
+++ b/Ingredii/Ingredii/AppDelegate.swift
@@ -1,0 +1,8 @@
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        return true
+    }
+}

--- a/Ingredii/Ingredii/Helpers/AppConstants.swift
+++ b/Ingredii/Ingredii/Helpers/AppConstants.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+enum AppConstants {
+    static let appName = "Ingredii"
+}

--- a/Ingredii/Ingredii/Helpers/Extensions.swift
+++ b/Ingredii/Ingredii/Helpers/Extensions.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension Date {
+    static func from(string: String) -> Date? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.date(from: string)
+    }
+}

--- a/Ingredii/Ingredii/Info.plist
+++ b/Ingredii/Ingredii/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>Ingredii</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.Ingredii</string>
+</dict>
+</plist>

--- a/Ingredii/Ingredii/LaunchScreen.storyboard
+++ b/Ingredii/Ingredii/LaunchScreen.storyboard
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="">
+    <scenes>
+        <!--Launch Screen-->
+        <scene sceneID="LaunchScreen">
+            <objects>
+                <view key="view" contentMode="scaleToFill" id="View">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                </view>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Ingredii/Ingredii/Models/PantryItem.swift
+++ b/Ingredii/Ingredii/Models/PantryItem.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct PantryItem: Identifiable, Codable {
+    let id = UUID()
+    var name: String
+    var quantity: Int
+    var expiry: Date?
+}

--- a/Ingredii/Ingredii/Resources/sample_inventory.json
+++ b/Ingredii/Ingredii/Resources/sample_inventory.json
@@ -1,0 +1,4 @@
+[
+  {"name": "Pasta", "quantity": 2, "expiry": "2024-01-01"},
+  {"name": "Tomato Sauce", "quantity": 1, "expiry": "2023-12-01"}
+]

--- a/Ingredii/Ingredii/SceneDelegate.swift
+++ b/Ingredii/Ingredii/SceneDelegate.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+        window = UIWindow(windowScene: windowScene)
+        window?.rootViewController = UIHostingController(rootView: ContentView())
+        window?.makeKeyAndVisible()
+    }
+}

--- a/Ingredii/Ingredii/Services/NetworkService.swift
+++ b/Ingredii/Ingredii/Services/NetworkService.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+class NetworkService {
+    func fetchData(from url: URL, completion: @escaping (Result<Data, Error>) -> Void) {
+        URLSession.shared.dataTask(with: url) { data, _, error in
+            if let error = error {
+                completion(.failure(error))
+            } else if let data = data {
+                completion(.success(data))
+            }
+        }.resume()
+    }
+}

--- a/Ingredii/Ingredii/Services/PersistenceService.swift
+++ b/Ingredii/Ingredii/Services/PersistenceService.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+class PersistenceService {
+    private let defaults = UserDefaults.standard
+
+    func save(items: [PantryItem]) {
+        if let data = try? JSONEncoder().encode(items) {
+            defaults.set(data, forKey: "pantry_items")
+        }
+    }
+
+    func load() -> [PantryItem] {
+        if let data = defaults.data(forKey: "pantry_items"),
+           let items = try? JSONDecoder().decode([PantryItem].self, from: data) {
+            return items
+        }
+        return []
+    }
+}

--- a/Ingredii/Ingredii/ViewModels/PantryViewModel.swift
+++ b/Ingredii/Ingredii/ViewModels/PantryViewModel.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+class PantryViewModel: ObservableObject {
+    @Published var items: [PantryItem] = []
+
+    func loadSampleData() {
+        if let url = Bundle.main.url(forResource: "sample_inventory", withExtension: "json"),
+           let data = try? Data(contentsOf: url),
+           let sampleItems = try? JSONDecoder().decode([PantryItem].self, from: data) {
+            items = sampleItems
+        }
+    }
+}

--- a/Ingredii/Ingredii/Views/ContentView.swift
+++ b/Ingredii/Ingredii/Views/ContentView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var viewModel = PantryViewModel()
+
+    var body: some View {
+        NavigationView {
+            PantryListView(items: viewModel.items)
+                .navigationTitle("Ingredii")
+        }
+        .onAppear {
+            viewModel.loadSampleData()
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/Ingredii/Ingredii/Views/ItemDetailView.swift
+++ b/Ingredii/Ingredii/Views/ItemDetailView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct ItemDetailView: View {
+    var item: PantryItem
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(item.name).font(.largeTitle)
+            Text("Quantity: \(item.quantity)")
+            if let expiry = item.expiry {
+                Text("Expires on: \(expiry.formatted(date: .abbreviated, time: .omitted))")
+            }
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+struct ItemDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        ItemDetailView(item: PantryItem(name: "Sugar", quantity: 1, expiry: nil))
+    }
+}

--- a/Ingredii/Ingredii/Views/PantryListView.swift
+++ b/Ingredii/Ingredii/Views/PantryListView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct PantryListView: View {
+    var items: [PantryItem]
+
+    var body: some View {
+        List(items) { item in
+            NavigationLink(destination: ItemDetailView(item: item)) {
+                Text("\(item.name) - \(item.quantity)")
+            }
+        }
+    }
+}
+
+struct PantryListView_Previews: PreviewProvider {
+    static var previews: some View {
+        PantryListView(items: [])
+    }
+}

--- a/IngrediiTests/ModelsTests.swift
+++ b/IngrediiTests/ModelsTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import Ingredii
+
+final class ModelsTests: XCTestCase {
+    func testPantryItemDecoding() throws {
+        let json = "{""name"": ""Sugar"", ""quantity"":1}".data(using: .utf8)!
+        let item = try JSONDecoder().decode(PantryItem.self, from: json)
+        XCTAssertEqual(item.name, "Sugar")
+    }
+}
+

--- a/IngrediiTests/ViewModelTests.swift
+++ b/IngrediiTests/ViewModelTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import Ingredii
+
+final class ViewModelTests: XCTestCase {
+    func testLoadSampleData() {
+        let viewModel = PantryViewModel()
+        viewModel.loadSampleData()
+        XCTAssertFalse(viewModel.items.isEmpty)
+    }
+}

--- a/IngrediiUITests/IngrediiUITests.swift
+++ b/IngrediiUITests/IngrediiUITests.swift
@@ -1,0 +1,8 @@
+import XCTest
+
+final class IngrediiUITests: XCTestCase {
+    func testExample() throws {
+        // Placeholder UI test
+        XCTAssertTrue(true)
+    }
+}


### PR DESCRIPTION
## Summary
- add directories for main app code, tests, and UI tests
- stub SwiftUI content and view models
- include basic services and helpers
- add placeholder Xcode project

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68771536e69c832cbc8a45b0a053377e