### PR TITLE
Add ESP32-CAM Blynk example

### DIFF
--- a/ArduinoCVBlynk/README.md
+++ b/ArduinoCVBlynk/README.md
@@ -1,0 +1,49 @@
+# Arduino Camera with Blynk and Computer Vision
+
+This example shows how to connect an ESP32-CAM to Blynk and a Python server
+that performs image classification using TensorFlow Lite.
+
+## Hardware
+- ESP32-CAM module
+- Power supply (5V)
+
+## Arduino Setup
+1. Install the **ESP32** board support in the Arduino IDE.
+2. Install the `Blynk` library from the Arduino Library Manager.
+3. Open `camera_blynk.ino` and update the following placeholders:
+   - `YOUR_WIFI_SSID` / `YOUR_WIFI_PASSWORD`
+   - `YOUR_BLYNK_TOKEN`
+   - `YOUR_SERVER_IP`
+4. Select the board **AI Thinker ESP32-CAM** and upload the sketch.
+
+The sketch captures a JPEG image every 3 seconds and posts it to the Python
+server. The response from the server is written to Blynk virtual pin **V0**.
+
+## Python Server
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Copy or train a TensorFlow Lite model and place it as `model.tflite` in this
+directory.
+3. Run the server:
+   ```bash
+   python server.py
+   ```
+   The server listens on port **5000** for image uploads.
+
+When an image is received, the server performs classification using the model
+and sends the result back to the ESP32-CAM. The same result is forwarded to
+Blynk through the Blynk HTTP API.
+
+## Blynk Configuration
+1. Create a new Blynk project and note the **auth token**.
+2. Add a **Value Display** widget to virtual pin **V0** to see classification
+   results.
+3. Ensure your phone and ESP32 are on the same network or use Blynk cloud.
+
+## Notes
+- This is a minimal example. Depending on your application, you may need to
+  adjust camera settings, model preprocessing, or memory usage.
+- TensorFlow Lite models may be trained using a dataset of food images so that
+  the classifier can recognize your specific items.

--- a/ArduinoCVBlynk/camera_blynk.ino
+++ b/ArduinoCVBlynk/camera_blynk.ino
@@ -1,0 +1,91 @@
+#include <WiFi.h>
+#include <BlynkSimpleEsp32.h>
+#include "esp_camera.h"
+#include <HTTPClient.h>
+
+// Replace with your network credentials
+const char* ssid = "YOUR_WIFI_SSID";
+const char* password = "YOUR_WIFI_PASSWORD";
+
+// Blynk authentication token
+char auth[] = "YOUR_BLYNK_TOKEN";
+
+// Server that will process images
+const char* serverUrl = "http://YOUR_SERVER_IP:5000/upload";
+
+void setup() {
+  Serial.begin(115200);
+  // Initialize camera with default pins for ESP32-CAM
+  camera_config_t config;
+  config.ledc_channel = LEDC_CHANNEL_0;
+  config.ledc_timer = LEDC_TIMER_0;
+  config.pin_d0 = 5;
+  config.pin_d1 = 18;
+  config.pin_d2 = 19;
+  config.pin_d3 = 21;
+  config.pin_d4 = 36;
+  config.pin_d5 = 39;
+  config.pin_d6 = 34;
+  config.pin_d7 = 35;
+  config.pin_xclk = 0;
+  config.pin_pclk = 22;
+  config.pin_vsync = 25;
+  config.pin_href = 23;
+  config.pin_sscb_sda = 26;
+  config.pin_sscb_scl = 27;
+  config.pin_pwdn = 32;
+  config.pin_reset = -1;
+  config.xclk_freq_hz = 20000000;
+  config.pixel_format = PIXFORMAT_JPEG;
+  config.frame_size = FRAMESIZE_VGA;
+  config.jpeg_quality = 10;
+  config.fb_count = 1;
+
+  // Camera init
+  esp_err_t err = esp_camera_init(&config);
+  if (err != ESP_OK) {
+    Serial.printf("Camera init failed with error 0x%x", err);
+    return;
+  }
+
+  // Connect WiFi and Blynk
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println("WiFi connected");
+  Blynk.begin(auth, ssid, password);
+}
+
+void loop() {
+  Blynk.run();
+
+  // Capture image
+  camera_fb_t * fb = esp_camera_fb_get();
+  if (!fb) {
+    Serial.println("Camera capture failed");
+    delay(1000);
+    return;
+  }
+
+  // Send image to server
+  if (WiFi.status() == WL_CONNECTED) {
+    HTTPClient http;
+    http.begin(serverUrl);
+    http.addHeader("Content-Type", "application/octet-stream");
+    int httpResponseCode = http.POST(fb->buf, fb->len);
+
+    if (httpResponseCode == HTTP_CODE_OK) {
+      String payload = http.getString();
+      // Send classification result to Blynk virtual pin V0
+      Blynk.virtualWrite(V0, payload);
+    } else {
+      Serial.printf("Server error: %d\n", httpResponseCode);
+    }
+    http.end();
+  }
+
+  esp_camera_fb_return(fb);
+  delay(3000); // wait 3 seconds before next capture
+}

--- a/ArduinoCVBlynk/requirements.txt
+++ b/ArduinoCVBlynk/requirements.txt
@@ -1,0 +1,5 @@
+flask
+opencv-python
+numpy
+tensorflow
+blynklib

--- a/ArduinoCVBlynk/server.py
+++ b/ArduinoCVBlynk/server.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Simple Flask server that receives an image from ESP32-CAM,
+performs classification using TensorFlow Lite and updates Blynk."""
+
+from flask import Flask, request, jsonify
+import numpy as np
+import tensorflow as tf
+import cv2
+import blynklib
+
+# Blynk credentials
+BLYNK_AUTH = 'YOUR_BLYNK_TOKEN'
+BLYNK = blynklib.Blynk(BLYNK_AUTH)
+
+# Load TFLite model (MobileNet or custom food classifier)
+interpreter = tf.lite.Interpreter(model_path='model.tflite')
+interpreter.allocate_tensors()
+input_details = interpreter.get_input_details()
+output_details = interpreter.get_output_details()
+
+app = Flask(__name__)
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    img_bytes = request.get_data()
+    img_array = np.frombuffer(img_bytes, np.uint8)
+    img = cv2.imdecode(img_array, cv2.IMREAD_COLOR)
+    # Preprocess for model
+    resized = cv2.resize(img, (224, 224))
+    input_data = np.expand_dims(resized.astype(np.float32) / 255.0, axis=0)
+    interpreter.set_tensor(input_details[0]['index'], input_data)
+    interpreter.invoke()
+    output_data = interpreter.get_tensor(output_details[0]['index'])
+    class_id = int(np.argmax(output_data))
+    confidence = float(np.max(output_data))
+    result = f"id:{class_id} conf:{confidence:.2f}"
+    # Update Blynk with classification result
+    BLYNK.virtual_write(0, result)
+    return result, 200
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- add simple ESP32-CAM sketch that posts images to a python server
- add python server using TensorFlow Lite and blynklib
- document setup instructions for Blynk and hardware
- include pip requirements

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6877a1d29b88832cae24f8795ba44685