### PR TITLE
Add on-device food classification and OCR

### DIFF
--- a/ArduinoCVBlynk/README.md
+++ b/ArduinoCVBlynk/README.md
@@ -1,7 +1,9 @@
 # Arduino Camera with Blynk and Computer Vision
 
 This example shows how to connect an ESP32-CAM to Blynk and a Python server
-that performs image classification using TensorFlow Lite.
+that performs image classification and optional on-device text recognition
+using TensorFlow Lite. The goal is to identify pantry items and, when needed,
+read the ingredient or nutrition label directly on the device.
 
 ## Hardware
 - ESP32-CAM module
@@ -24,17 +26,27 @@ server. The response from the server is written to Blynk virtual pin **V0**.
    ```bash
    pip install -r requirements.txt
    ```
-2. Copy or train a TensorFlow Lite model and place it as `model.tflite` in this
-directory.
-3. Run the server:
+2. Download the **On-Device Food Classifier** TFLite model from TensorFlow Hub
+   and save it as `food_classifier.tflite` in this directory. Optionally place
+   the accompanying `labels.txt` file alongside the model so results include the
+   label name.
+3. (Optional) Download the ML Kit Text Recognition v2 (on-device) model and
+   save it as `text_recognizer.tflite` if you want to enable OCR for scanning
+   ingredient lists.
+4. Run the server:
    ```bash
    python server.py
    ```
    The server listens on port **5000** for image uploads.
 
-When an image is received, the server performs classification using the model
-and sends the result back to the ESP32-CAM. The same result is forwarded to
-Blynk through the Blynk HTTP API.
+When an image is received the server performs one of two actions depending on
+the query parameter:
+
+- **Default**: classify the food item using the On-Device Food Classifier and
+  forward the result to both the ESP32-CAM and Blynk.
+- **`mode=ocr`**: run the text recognizer on the uploaded image and return the
+  detected UTF‑8 text. This can be used after cropping the label region on the
+  device.
 
 ## Blynk Configuration
 1. Create a new Blynk project and note the **auth token**.

--- a/ArduinoCVBlynk/labels.txt
+++ b/ArduinoCVBlynk/labels.txt
@@ -1,0 +1,3 @@
+Greek salad
+sushi
+potato chips

--- a/ArduinoCVBlynk/requirements.txt
+++ b/ArduinoCVBlynk/requirements.txt
@@ -3,3 +3,4 @@ opencv-python
 numpy
 tensorflow
 blynklib
+tflite-support

--- a/ArduinoCVBlynk/server.py
+++ b/ArduinoCVBlynk/server.py
@@ -1,42 +1,119 @@
 #!/usr/bin/env python3
-"""Simple Flask server that receives an image from ESP32-CAM,
-performs classification using TensorFlow Lite and updates Blynk."""
+"""Simple Flask server used with the ESP32-CAM example.
+
+The server can perform two tasks using TensorFlow Lite models:
+
+1. Classify the food item in the uploaded image using the **On-Device Food
+   Classifier** from TensorFlow Hub.
+2. Optionally run on-device text recognition using the ML Kit Text Recognition
+   model. This allows scanning the ingredient list or nutrition label when the
+   client requests it.
+
+Classification results are forwarded to Blynk on virtual pin ``V0``.
+"""
 
 from flask import Flask, request, jsonify
 import numpy as np
-import tensorflow as tf
 import cv2
 import blynklib
+try:
+    import tensorflow as tf
+except ImportError:  # pragma: no cover - tensorflow not installed during tests
+    tf = None
+
+try:
+    from tflite_support.task import vision
+    from tflite_support.task.text import text_recognizer
+    from tflite_support.task.core import BaseOptions
+except Exception:  # pragma: no cover - optional dependency
+    vision = None
+    text_recognizer = None
+    BaseOptions = None
 
 # Blynk credentials
 BLYNK_AUTH = 'YOUR_BLYNK_TOKEN'
 BLYNK = blynklib.Blynk(BLYNK_AUTH)
 
-# Load TFLite model (MobileNet or custom food classifier)
-interpreter = tf.lite.Interpreter(model_path='model.tflite')
-interpreter.allocate_tensors()
-input_details = interpreter.get_input_details()
-output_details = interpreter.get_output_details()
+###############################
+# Model loading
+###############################
+
+if tf:
+    food_interpreter = tf.lite.Interpreter(model_path='food_classifier.tflite')
+    food_interpreter.allocate_tensors()
+    food_input = food_interpreter.get_input_details()
+    food_output = food_interpreter.get_output_details()
+else:  # pragma: no cover - tensorflow missing
+    food_interpreter = None
+    food_input = []
+    food_output = []
+
+LABELS = []
+try:
+    with open('labels.txt') as f:
+        LABELS = [l.strip() for l in f if l.strip()]
+except FileNotFoundError:  # pragma: no cover
+    pass
+
+if text_recognizer and BaseOptions:
+    text_options = text_recognizer.TextRecognizerOptions(
+        base_options=BaseOptions(model_path='text_recognizer.tflite')
+    )
+    TEXT_RECOGNIZER = text_recognizer.TextRecognizer.create_from_options(text_options)
+else:  # pragma: no cover - optional dependency not installed
+    TEXT_RECOGNIZER = None
 
 app = Flask(__name__)
 
+
+def classify(img: np.ndarray) -> dict:
+    """Run the food classification model on the provided BGR image."""
+    if not food_interpreter:
+        return {"error": "TensorFlow not available"}
+    resized = cv2.resize(img, (224, 224))
+    input_data = np.expand_dims(resized.astype(np.float32) / 255.0, axis=0)
+    food_interpreter.set_tensor(food_input[0]['index'], input_data)
+    food_interpreter.invoke()
+    output_data = food_interpreter.get_tensor(food_output[0]['index'])[0]
+    class_id = int(np.argmax(output_data))
+    confidence = float(np.max(output_data))
+    label = LABELS[class_id] if class_id < len(LABELS) else str(class_id)
+    return {"label": label, "confidence": confidence}
+
+
+def recognize_text(img: np.ndarray) -> dict:
+    """Run OCR on the provided BGR image."""
+    if TEXT_RECOGNIZER is None:
+        return {"error": "Text recognizer unavailable"}
+    rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+    input_image = vision.TensorImage.create_from_array(rgb)
+    result = TEXT_RECOGNIZER.recognize(input_image)
+    text = " ".join([block.text for block in result.blocks])
+    return {"text": text}
+
+
 @app.route('/upload', methods=['POST'])
 def upload():
+    """Handle image upload.
+
+    The client can pass ``mode=ocr`` as a query parameter to run text
+    recognition instead of food classification.
+    """
+
     img_bytes = request.get_data()
     img_array = np.frombuffer(img_bytes, np.uint8)
     img = cv2.imdecode(img_array, cv2.IMREAD_COLOR)
-    # Preprocess for model
-    resized = cv2.resize(img, (224, 224))
-    input_data = np.expand_dims(resized.astype(np.float32) / 255.0, axis=0)
-    interpreter.set_tensor(input_details[0]['index'], input_data)
-    interpreter.invoke()
-    output_data = interpreter.get_tensor(output_details[0]['index'])
-    class_id = int(np.argmax(output_data))
-    confidence = float(np.max(output_data))
-    result = f"id:{class_id} conf:{confidence:.2f}"
-    # Update Blynk with classification result
-    BLYNK.virtual_write(0, result)
-    return result, 200
+
+    mode = request.args.get('mode', 'classify')
+    if mode == 'ocr':
+        result = recognize_text(img)
+        return jsonify(result)
+
+    result = classify(img)
+    if 'label' in result:
+        # Update Blynk with classification result
+        BLYNK.virtual_write(0, f"{result['label']}: {result['confidence']:.2f}")
+    return jsonify(result)
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)

--- a/readme
+++ b/readme
@@ -2,6 +2,10 @@
 
 Simple pantry inventory management example built with SwiftUI.
 
+This repository also contains an optional computer vision example that uses an
+ESP32-CAM and TensorFlow Lite models to automatically identify pantry items or
+scan text from a product label.
+
 ## Features
 
 - Display a list of pantry items
@@ -18,3 +22,16 @@ Open `Ingredii/Ingredii.xcodeproj` in Xcode and run the `Ingredii` target.
 ## Tests
 
 Unit tests reside in the `IngrediiTests` group. Run them from Xcode via the `Product` → `Test` menu.
+
+## Computer Vision Example
+
+The `ArduinoCVBlynk` directory contains a companion project demonstrating how
+to capture images from an ESP32‑CAM and classify them on-device. It uses two
+TensorFlow Lite models:
+
+1. **On-Device Food Classifier** – recognizes dozens of common dishes and
+   snacks.
+2. **ML Kit Text Recognition v2** – reads printed text from the image when
+   invoked in `mode=ocr`.
+
+See `ArduinoCVBlynk/README.md` for setup instructions.


### PR DESCRIPTION
## Summary
- enhance server to support ML Kit OCR and food classification
- document usage of TensorFlow Lite models
- include labels.txt sample and update requirements
- mention computer vision example in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877a96cf7dc832ca38ccf8818df3aa2